### PR TITLE
Fix test case for binding expression ranges

### DIFF
--- a/test/live-range.test.ts
+++ b/test/live-range.test.ts
@@ -24,7 +24,7 @@ Generated source:
 
 const scopeNames = ["log", "x", "msg", "\"foo\"", "\"bar\""];
 const encodedOriginalScopes = ["AACAAC,AkBECAE,EC,IO"];
-const encodedGeneratedRanges = "AKAADFGCAI,AGACAICG,mB;AGAAAEAI,mB,A";
+const encodedGeneratedRanges = "AKAADGFCAI,AGACAICG,mB;AGAAAEAI,mB,A";
 
 const originalScopes: OriginalScope[] = [
   {


### PR DESCRIPTION
When parsing a binding set, the `names` index is first, then a peek for `M`, then (M-1) parses of `line`/`col`/`name`.

The old test code cases `DFGCAI` decodes to `-1`, `-2`, `3`, `1`, `0`, `4`. The `D` decodes the first param's unavailable expression. Then we move on to the second param's initial `names` index, which decodes `F` (`-2`). But `-2` is not a valid names index, it looks like we mixed the `M` and `names` order.